### PR TITLE
add: 環境変数からsecrets.tomlを動的に作成する処理を追加

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,11 @@
 import os
 import streamlit as st
 from dotenv import load_dotenv
+from util import create_secrets_toml
 
 load_dotenv()
+
+create_secrets_toml()
 
 APP_LOGO = os.environ["APP_LOGO"]
 st.logo(image=APP_LOGO, size="large")

--- a/app/util.py
+++ b/app/util.py
@@ -1,0 +1,28 @@
+import os
+import toml
+from pathlib import Path
+
+def create_secrets_toml():
+    """環境変数からsecrets.tomlを生成"""
+
+    secrets_data = {
+        'auth': {
+            'redirect_uri': os.getenv('REDIRECT_URI', 'http://localhost:8502/oauth2callback'),
+            'cookie_secret': os.getenv('COOKIE_SECRET'),
+            'auth0': {
+                'client_id': os.getenv('CLIENT_ID'),
+                'client_secret': os.getenv('CLIENT_SECRET'),
+                'server_metadata_url': os.getenv('SERVER_METADATA_URL'),
+                'client_kwargs': {
+                    'prompt': os.getenv('CLIENT_KWARGS_PROMPT'),
+                }
+            }
+        }
+    }
+
+    # .streamlit/secrets.tomlを作成
+    streamlit_dir = Path.home() / '.streamlit'
+    streamlit_dir.mkdir(exist_ok=True)
+
+    with open(streamlit_dir / 'secrets.toml', 'w') as f:
+        toml.dump(secrets_data, f)


### PR DESCRIPTION
st.loginなどがsecrets.tomlを参照するため。
Community Cloudにデプロイする場合は問題ないが、AWSやGoogle Cloudにデプロイする場合はsecrets.tomlを用意する必要がある。